### PR TITLE
Add soundings endpoints to CLI

### DIFF
--- a/windborne/__init__.py
+++ b/windborne/__init__.py
@@ -19,7 +19,9 @@ from .observations_api import (
     get_predicted_path,
     get_current_location,
     get_flight_path,
-    get_constellation_status
+    get_constellation_status,
+    get_soundings,
+    get_sounding
 )
 
 # Import Forecasts API functions
@@ -58,6 +60,8 @@ __all__ = [
     "get_current_location",
     "get_flight_path",
     "get_constellation_status",
+    "get_soundings",
+    "get_sounding",
 
     "get_point_forecasts",
     "get_point_forecasts_interpolated",

--- a/windborne/cli.py
+++ b/windborne/cli.py
@@ -18,6 +18,8 @@ from . import (
     get_current_location,
     get_flight_path,
     get_constellation_status,
+    get_soundings,
+    get_sounding,
 
     get_point_forecasts,
     get_point_forecasts_interpolated,
@@ -142,6 +144,24 @@ def main():
     # Get Constellation Status Command
     constellation_parser = subparsers.add_parser('constellation_status', help='Get current constellation status with locations')
     constellation_parser.add_argument('output', nargs='?', help='Output file (.csv or .json)')
+
+    # Soundings Command
+    soundings_parser = subparsers.add_parser('soundings', help='List/search atmospheric soundings')
+    soundings_parser.add_argument('-m', '--mission-id', help='Filter by mission ID')
+    soundings_parser.add_argument('-mt', '--min-time', help='Filter soundings starting at or after this time')
+    soundings_parser.add_argument('-xt', '--max-time', help='Filter soundings ending at or before this time')
+    soundings_parser.add_argument('-ma', '--min-altitude', type=float, help='Exclude soundings below this altitude (meters)')
+    soundings_parser.add_argument('-xa', '--max-altitude', type=float, help='Exclude soundings above this altitude (meters)')
+    soundings_parser.add_argument('-ml', '--min-lat', type=float, help='Minimum latitude')
+    soundings_parser.add_argument('-xl', '--max-lat', type=float, help='Maximum latitude')
+    soundings_parser.add_argument('-mg', '--min-lon', type=float, help='Minimum longitude')
+    soundings_parser.add_argument('-xg', '--max-lon', type=float, help='Maximum longitude')
+    soundings_parser.add_argument('output', nargs='?', help='Output file (.csv or .json)')
+
+    # Sounding by ID Command
+    sounding_parser = subparsers.add_parser('sounding', help='Get full sounding data by ID')
+    sounding_parser.add_argument('sounding_id', help='Sounding ID (UUID)')
+    sounding_parser.add_argument('output', nargs='?', help='Output file (.csv or .json)')
 
     ####################################################################################################################
     # FORECASTS API FUNCTIONS
@@ -410,6 +430,28 @@ def main():
         get_constellation_status(
             output_file=args.output,
             print_results=(not args.output)
+        )
+
+    elif args.command == 'soundings':
+        get_soundings(
+            mission_id=args.mission_id,
+            min_time=args.min_time,
+            max_time=args.max_time,
+            min_altitude=args.min_altitude,
+            max_altitude=args.max_altitude,
+            min_latitude=args.min_lat,
+            max_latitude=args.max_lat,
+            min_longitude=args.min_lon,
+            max_longitude=args.max_lon,
+            output_file=args.output,
+            print_response=(not args.output)
+        )
+
+    elif args.command == 'sounding':
+        get_sounding(
+            sounding_id=args.sounding_id,
+            output_file=args.output,
+            print_response=(not args.output)
         )
 
 


### PR DESCRIPTION
## Summary

- Adds `get_soundings()` and `get_sounding()` to `observations_api.py` to cover the new `GET /observations/v1/soundings` and `GET /observations/v1/soundings/<id>` endpoints added in sensor-data-api ([dec5971](https://github.com/windborne/sensor-data-api/commit/dec5971))
- Adds CLI subcommands `windborne soundings` (list/search with filtering) and `windborne sounding <id>` (fetch full profile)
- Exports new functions in `__init__.py`

The API docs in oracle (`frontends/api/src/pages/observations/version_1/soundings/`) already reference these functions — this PR brings the CLI into sync.

### CLI flags for `windborne soundings`
| Flag | Description |
|------|-------------|
| `-m, --mission-id` | Filter by mission ID |
| `-mt, --min-time` | Min time filter |
| `-xt, --max-time` | Max time filter |
| `-ma, --min-altitude` | Min altitude (meters) |
| `-xa, --max-altitude` | Max altitude (meters) |
| `-ml, --min-lat` | Min latitude |
| `-xl, --max-lat` | Max latitude |
| `-mg, --min-lon` | Min longitude |
| `-xg, --max-lon` | Max longitude |

## Test plan
- [ ] `windborne soundings` prints paginated sounding metadata table
- [ ] `windborne soundings output.json` saves response to file
- [ ] `windborne soundings -m <mission_id> -mt 2026-01-20T00:00:00Z output.csv` filters correctly
- [ ] `windborne sounding <sounding_id>` prints full sounding profile
- [ ] `windborne sounding <sounding_id> output.json` saves to file
- [ ] `from windborne import get_soundings, get_sounding` works in Python