### PR TITLE
Add missing station forecast, interpolated sounding, and super_obs geo filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "windborne"
-version = "1.4.3"
+version = "1.5.0"
 description = "A Python library for interacting with WindBorne Data and Forecasts API"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [

--- a/windborne/__init__.py
+++ b/windborne/__init__.py
@@ -31,6 +31,10 @@ from .forecasts_api import (
     get_run_information,
     get_variables,
 
+    get_available_stations,
+    get_station_forecast,
+    get_interpolated_sounding,
+
     get_gridded_forecast,
     get_full_gridded_forecast,
 
@@ -66,9 +70,13 @@ __all__ = [
     "get_run_information",
     "get_variables",
     
+    "get_available_stations",
+    "get_station_forecast",
+    "get_interpolated_sounding",
+
     "get_gridded_forecast",
     "get_full_gridded_forecast",
-    
+
     "get_tropical_cyclones",
 
     "get_population_weighted_hdds",

--- a/windborne/cli.py
+++ b/windborne/cli.py
@@ -102,6 +102,7 @@ def main():
     super_obs_page_parser.add_argument('-xl', '--max-latitude', type=float, help='Maximum latitude filter')
     super_obs_page_parser.add_argument('-mg', '--min-longitude', type=float, help='Minimum longitude filter')
     super_obs_page_parser.add_argument('-xg', '--max-longitude', type=float, help='Maximum longitude filter')
+    super_obs_page_parser.add_argument('-id', '--include-ids', action='store_true', help='Include observation IDs')
     super_obs_page_parser.add_argument('-mn', '--include-mission-name', action='store_true', help='Include mission names')
     super_obs_page_parser.add_argument('-u', '--include-updated-at', action='store_true', help='Include update timestamps')
     super_obs_page_parser.add_argument('output', nargs='?', help='Output file')

--- a/windborne/cli.py
+++ b/windborne/cli.py
@@ -29,7 +29,11 @@ from . import (
     get_tropical_cyclones,
     get_population_weighted_hdds,
     get_population_weighted_cdds,
-    get_calculation_times_degree_days
+    get_calculation_times_degree_days,
+
+    get_available_stations,
+    get_station_forecast,
+    get_interpolated_sounding
 )
 
 from pprint import pprint
@@ -52,6 +56,10 @@ def main():
     super_obs_parser.add_argument('-b', '--bucket-hours', type=float, default=6.0, help='Hours per bucket')
     super_obs_parser.add_argument('-d', '--output-dir', help='Directory path where the separate files should be saved. If not provided, files will be saved in current directory.')
     super_obs_parser.add_argument('-m', '--mission-id', help='Filter by mission ID')
+    super_obs_parser.add_argument('-ml', '--min-latitude', type=float, help='Minimum latitude filter')
+    super_obs_parser.add_argument('-xl', '--max-latitude', type=float, help='Maximum latitude filter')
+    super_obs_parser.add_argument('-mg', '--min-longitude', type=float, help='Minimum longitude filter')
+    super_obs_parser.add_argument('-xg', '--max-longitude', type=float, help='Maximum longitude filter')
     super_obs_parser.add_argument('output', help='Save output to a single file (filename.csv, filename.json or filename.little_r) or to or to multiple files (csv, json, netcdf or little_r)')
 
     # Observations Command
@@ -90,6 +98,10 @@ def main():
     super_obs_page_parser.add_argument('-mt', '--min-time', help='Minimum time filter (YYYY-MM-DD_HH:MM, "YYYY-MM-DD HH:MM:SS" or YYYY-MM-DDTHH:MM:SS.fffZ)')
     super_obs_page_parser.add_argument('-xt', '--max-time', help='Maximum time filter (YYYY-MM-DD_HH:MM, "YYYY-MM-DD HH:MM:SS" or YYYY-MM-DDTHH:MM:SS.fffZ)')
     super_obs_page_parser.add_argument('-m', '--mission-id', help='Filter by mission ID')
+    super_obs_page_parser.add_argument('-ml', '--min-latitude', type=float, help='Minimum latitude filter')
+    super_obs_page_parser.add_argument('-xl', '--max-latitude', type=float, help='Maximum latitude filter')
+    super_obs_page_parser.add_argument('-mg', '--min-longitude', type=float, help='Minimum longitude filter')
+    super_obs_page_parser.add_argument('-xg', '--max-longitude', type=float, help='Maximum longitude filter')
     super_obs_page_parser.add_argument('-mn', '--include-mission-name', action='store_true', help='Include mission names')
     super_obs_page_parser.add_argument('-u', '--include-updated-at', action='store_true', help='Include update timestamps')
     super_obs_page_parser.add_argument('output', nargs='?', help='Output file')
@@ -172,6 +184,29 @@ def main():
     points_interpolated_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
     points_interpolated_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
     points_interpolated_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
+
+    # Station Forecasts
+    ####################################################################################################################
+
+    # Available Stations Command
+    available_stations_parser = subparsers.add_parser('available_stations', help='List all weather stations with station-specific forecasts')
+    available_stations_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
+    available_stations_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
+
+    # Station Forecast Command
+    station_forecast_parser = subparsers.add_parser('station_forecast', help='Get weather forecast for a specific station')
+    station_forecast_parser.add_argument('station_id', help='ICAO station identifier (e.g., PANC, KJFK, SFO)')
+    station_forecast_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
+    station_forecast_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
+
+    # Interpolated Sounding Command
+    interpolated_sounding_parser = subparsers.add_parser('interpolated_sounding', help='Get interpolated forecast sounding for a coordinate')
+    interpolated_sounding_parser.add_argument('coordinates', help='Coordinates as "latitude,longitude"')
+    interpolated_sounding_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm-5c)')
+    interpolated_sounding_parser.add_argument('-t', '--time', help='Forecast valid time (ISO 8601)')
+    interpolated_sounding_parser.add_argument('-i', '--init-time', help='Initialization time (ISO 8601)')
+    interpolated_sounding_parser.add_argument('-fh', '--forecast-hour', type=int, help='Forecast hour offset')
+    interpolated_sounding_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
 
     # GRIDDED FORECASTS
     ####################################################################################################################
@@ -259,6 +294,10 @@ def main():
             end_time=args.end_time,
             output_file=output_file,
             mission_id=args.mission_id,
+            min_latitude=args.min_latitude,
+            max_latitude=args.max_latitude,
+            min_longitude=args.min_longitude,
+            max_longitude=args.max_longitude,
             bucket_hours=args.bucket_hours,
             output_dir=output_dir,
             output_format=output_format
@@ -364,7 +403,11 @@ def main():
                 include_ids=args.include_ids,
                 include_mission_name=args.include_mission_name,
                 include_updated_at=args.include_updated_at,
-                mission_id=args.mission_id
+                mission_id=args.mission_id,
+                min_latitude=args.min_latitude,
+                max_latitude=args.max_latitude,
+                min_longitude=args.min_longitude,
+                max_longitude=args.max_longitude
             ), indent=4))
         else:
             get_super_observations_page(
@@ -375,6 +418,10 @@ def main():
                 include_mission_name=args.include_mission_name,
                 include_updated_at=args.include_updated_at,
                 mission_id=args.mission_id,
+                min_latitude=args.min_latitude,
+                max_latitude=args.max_latitude,
+                min_longitude=args.min_longitude,
+                max_longitude=args.max_longitude,
                 output_file=args.output
             )
 
@@ -450,6 +497,32 @@ def main():
             max_forecast_hour=max_forecast_hour,
             initialization_time=initialization_time,
             ens_member=getattr(args, 'ens_member', None),
+            output_file=args.output_file,
+            model=args.model,
+            print_response=(not args.output_file)
+        )
+
+    elif args.command == 'available_stations':
+        get_available_stations(
+            output_file=args.output_file,
+            model=args.model,
+            print_response=(not args.output_file)
+        )
+
+    elif args.command == 'station_forecast':
+        get_station_forecast(
+            station_id=args.station_id,
+            output_file=args.output_file,
+            model=args.model,
+            print_response=(not args.output_file)
+        )
+
+    elif args.command == 'interpolated_sounding':
+        get_interpolated_sounding(
+            coordinates=args.coordinates,
+            time=args.time,
+            initialization_time=args.init_time,
+            forecast_hour=args.forecast_hour,
             output_file=args.output_file,
             model=args.model,
             print_response=(not args.output_file)

--- a/windborne/forecasts_api.py
+++ b/windborne/forecasts_api.py
@@ -623,6 +623,127 @@ def get_calculation_times_degree_days(ens_member=None, print_response=False, mod
     return response
 
 
+# Station forecasts
+def get_available_stations(output_file=None, print_response=False, model='wm'):
+    """
+    Get the list of ASOS weather stations with station-specific forecasts.
+
+    Args:
+        output_file (str, optional): Path to save the response data (.json or .csv)
+        print_response (bool, optional): Whether to print a formatted table
+        model (str, optional): Forecast model (e.g., wm, wm4)
+
+    Returns:
+        list: Array of station objects with station_id, station_name, latitude, longitude
+    """
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{model}/point_forecast/stations")
+
+    if output_file:
+        save_arbitrary_response(output_file, response)
+
+    if print_response and response is not None:
+        stations = response if isinstance(response, list) else response.get('stations', response)
+        print(f"Available stations ({len(stations)}):\n")
+        print_table(stations, keys=['station_id', 'station_name', 'latitude', 'longitude'],
+                    headers=['Station ID', 'Station Name', 'Latitude', 'Longitude'])
+
+    return response
+
+
+def get_station_forecast(station_id, output_file=None, print_response=False, model='wm'):
+    """
+    Get the weather forecast for a specific ASOS station.
+
+    Args:
+        station_id (str): ICAO station identifier (e.g., PANC, KJFK, SFO)
+        output_file (str, optional): Path to save the response data (.json or .csv)
+        print_response (bool, optional): Whether to print a formatted table
+        model (str, optional): Forecast model (e.g., wm, wm4)
+
+    Returns:
+        dict: Forecast data including station_id, latitude, longitude, model,
+              initialization_time, forecast_zero, and forecast array
+    """
+    if not station_id:
+        print("To get a station forecast you must provide a station_id.")
+        return
+
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{model}/point_forecast/stations/{station_id}")
+
+    if output_file:
+        save_arbitrary_response(output_file, response, csv_data_key='forecast')
+
+    if print_response and response is not None:
+        print(f"Station: {response.get('station_id')}")
+        print(f"Location: ({response.get('latitude')}, {response.get('longitude')})")
+        print(f"Model: {response.get('model')}")
+        print(f"Initialization time: {response.get('initialization_time')}")
+        print(f"Forecast zero: {response.get('forecast_zero')}\n")
+
+        keys = ['time', 'temperature_2m', 'dewpoint_2m', 'wind_u_10m', 'wind_v_10m', 'precipitation', 'pressure_msl']
+        headers = ['Time', '2m Temp (°C)', '2m Dewpoint (°C)', 'Wind U (m/s)', 'Wind V (m/s)', 'Precip (mm)', 'MSL Pressure (hPa)']
+        print_table(response.get('forecast', []), keys=keys, headers=headers)
+
+    return response
+
+
+# Interpolated sounding
+def get_interpolated_sounding(coordinates, time=None, initialization_time=None, forecast_hour=None, output_file=None, print_response=False, model='wm'):
+    """
+    Get an interpolated forecast sounding (vertical atmospheric profile) for a coordinate.
+
+    Args:
+        coordinates (str): Coordinates as "latitude,longitude"
+        time (str, optional): Forecast valid time (ISO 8601). Use instead of initialization_time + forecast_hour.
+        initialization_time (str, optional): Model initialization time (ISO 8601). Use with forecast_hour.
+        forecast_hour (int, optional): Forecast hour offset from initialization_time.
+        output_file (str, optional): Path to save the response data (.json or .csv)
+        print_response (bool, optional): Whether to print a formatted table
+        model (str, optional): Forecast model (e.g., wm, wm-5c)
+
+    Returns:
+        dict: Sounding data including initialization_time, forecast_zero, time,
+              forecast_hour, latitude, longitude, and data array of vertical levels
+    """
+    if not coordinates:
+        print("To get an interpolated sounding you must provide coordinates.")
+        return
+
+    formatted_coordinates = coordinates.replace(" ", "")
+
+    params = {"coordinates": formatted_coordinates}
+
+    if time is None and (initialization_time is None or forecast_hour is None):
+        print("Error: you must provide either time or initialization_time and forecast_hour.")
+        return
+    elif time is not None and (initialization_time is not None or forecast_hour is not None):
+        print("Warning: time, initialization_time, forecast_hour all provided; using initialization_time and forecast_hour.")
+
+    if initialization_time is not None and forecast_hour is not None:
+        params["initialization_time"] = parse_time(initialization_time, init_time_flag=True)
+        params["forecast_hour"] = forecast_hour
+    elif time:
+        params["time"] = parse_time(time)
+
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{model}/point_forecast/interpolated_sounding", params=params)
+
+    if output_file:
+        save_arbitrary_response(output_file, response, csv_data_key='data')
+
+    if print_response and response is not None:
+        print(f"Initialization time: {response.get('initialization_time')}")
+        print(f"Forecast zero: {response.get('forecast_zero')}")
+        print(f"Time: {response.get('time')}")
+        print(f"Forecast hour: {response.get('forecast_hour')}")
+        print(f"Location: ({response.get('latitude')}, {response.get('longitude')})\n")
+
+        keys = ['pressure_hpa', 'altitude_m', 'temperature_c', 'dewpoint_c', 'specific_humidity_kg_kg', 'wind_u_ms', 'wind_v_ms']
+        headers = ['Pressure (hPa)', 'Altitude (m)', 'Temp (°C)', 'Dewpoint (°C)', 'Spec. Humidity (kg/kg)', 'Wind U (m/s)', 'Wind V (m/s)']
+        print_table(response.get('data', []), keys=keys, headers=headers)
+
+    return response
+
+
 def get_point_forecasts_interpolated(coordinates, min_forecast_time=None, max_forecast_time=None, min_forecast_hour=None, max_forecast_hour=None, initialization_time=None, ens_member=None, output_file=None, print_response=False, model='wm'):
     """
     Get interpolated point forecasts from the API.

--- a/windborne/forecasts_api.py
+++ b/windborne/forecasts_api.py
@@ -223,7 +223,7 @@ def get_gridded_forecast(variable, time=None, initialization_time=None, forecast
     if time is None and (initialization_time is None or forecast_hour is None):
         print("Error: you must provide either time or initialization_time and forecast_hour.")
         return
-    elif time is not None and (initialization_time is not None or forecast_hour is not None):
+    elif time is not None and initialization_time is not None and forecast_hour is not None:
         print("Warning: time, initialization_time, forecast_hour all provided; using initialization_time and forecast_hour.")
 
     params = {}
@@ -716,7 +716,7 @@ def get_interpolated_sounding(coordinates, time=None, initialization_time=None, 
     if time is None and (initialization_time is None or forecast_hour is None):
         print("Error: you must provide either time or initialization_time and forecast_hour.")
         return
-    elif time is not None and (initialization_time is not None or forecast_hour is not None):
+    elif time is not None and initialization_time is not None and forecast_hour is not None:
         print("Warning: time, initialization_time, forecast_hour all provided; using initialization_time and forecast_hour.")
 
     if initialization_time is not None and forecast_hour is not None:

--- a/windborne/observations_api.py
+++ b/windborne/observations_api.py
@@ -77,9 +77,9 @@ def get_observations_page(since=None, min_time=None, max_time=None, include_ids=
     return response
 
 
-def get_super_observations_page(since=None, min_time=None, max_time=None, include_ids=None, include_mission_name=None, include_updated_at=None, mission_id=None, output_file=None):
+def get_super_observations_page(since=None, min_time=None, max_time=None, include_ids=None, include_mission_name=None, include_updated_at=None, mission_id=None, min_latitude=None, max_latitude=None, min_longitude=None, max_longitude=None, output_file=None):
     """
-    Retrieves super observations page based on specified filters.
+    Retrieves super observations page based on specified filters including geographical bounds.
 
     Args:
         since (str): Filter observations after this timestamp.
@@ -89,6 +89,10 @@ def get_super_observations_page(since=None, min_time=None, max_time=None, includ
         include_mission_name (bool): Include mission names in response.
         include_updated_at (bool): Include update timestamps in response.
         mission_id (str): Filter observations by mission ID.
+        min_latitude (float): Minimum latitude boundary.
+        max_latitude (float): Maximum latitude boundary.
+        min_longitude (float): Minimum longitude boundary.
+        max_longitude (float): Maximum longitude boundary.
         output_file (str): Optional path to save the response data.
                            If provided, saves the data in CSV format.
 
@@ -107,6 +111,14 @@ def get_super_observations_page(since=None, min_time=None, max_time=None, includ
         params["max_time"] = to_unix_timestamp(max_time)
     if mission_id:
         params["mission_id"] = mission_id
+    if min_latitude:
+        params["min_latitude"] = min_latitude
+    if max_latitude:
+        params["max_latitude"] = max_latitude
+    if min_longitude:
+        params["min_longitude"] = min_longitude
+    if max_longitude:
+        params["max_longitude"] = max_longitude
     if include_ids:
         params["include_ids"] = True
     if include_mission_name:
@@ -480,7 +492,7 @@ def poll_observations(**kwargs):
 
     get_observations(**kwargs, exit_at_end=False)
 
-def get_super_observations(start_time, end_time=None, mission_id=None, include_updated_at=True, output_file=None, bucket_hours=6.0, output_format=None, output_dir=None, callback=None, custom_save=None, exit_at_end=True, verbose=True):
+def get_super_observations(start_time, end_time=None, mission_id=None, min_latitude=None, max_latitude=None, min_longitude=None, max_longitude=None, include_updated_at=True, output_file=None, bucket_hours=6.0, output_format=None, output_dir=None, callback=None, custom_save=None, exit_at_end=True, verbose=True):
     """
     Fetches super observations between a start time and an optional end time and saves to files in specified format.
     Files are broken up into time buckets, with filenames containing the time at the mid-point of the bucket.
@@ -492,6 +504,10 @@ def get_super_observations(start_time, end_time=None, mission_id=None, include_u
         end_time (str): Optional. A date string, supporting formats YYYY-MM-DD HH:MM:SS, YYYY-MM-DD_HH:MM and ISO strings,
                         representing the end time of fetching data. If not provided, current time is used as end time.
         mission_id (str): Filter observations by mission ID.
+        min_latitude (float): Minimum latitude boundary.
+        max_latitude (float): Maximum latitude boundary.
+        min_longitude (float): Minimum longitude boundary.
+        max_longitude (float): Maximum longitude boundary.
         include_updated_at (bool): Include update timestamps in response.
         output_file (str): Saves all data to a single file instead of bucketing.
                             Supported formats are '.csv', '.json', '.little_r' and '.nc'
@@ -514,6 +530,10 @@ def get_super_observations(start_time, end_time=None, mission_id=None, include_u
         'min_time': start_time,
         'max_time': end_time,
         'mission_id': mission_id,
+        'min_latitude': min_latitude,
+        'max_latitude': max_latitude,
+        'min_longitude': min_longitude,
+        'max_longitude': max_longitude,
         'include_updated_at': include_updated_at,
         'include_ids': True,
         'include_mission_name': True

--- a/windborne/observations_api.py
+++ b/windborne/observations_api.py
@@ -52,13 +52,13 @@ def get_observations_page(since=None, min_time=None, max_time=None, include_ids=
         params["max_time"] = to_unix_timestamp(max_time)
     if mission_id:
         params["mission_id"] = mission_id
-    if min_latitude:
+    if min_latitude is not None:
         params["min_latitude"] = min_latitude
-    if max_latitude:
+    if max_latitude is not None:
         params["max_latitude"] = max_latitude
-    if min_longitude:
+    if min_longitude is not None:
         params["min_longitude"] = min_longitude
-    if max_longitude:
+    if max_longitude is not None:
         params["max_longitude"] = max_longitude
     if include_ids:
         params["include_ids"] = True
@@ -66,7 +66,7 @@ def get_observations_page(since=None, min_time=None, max_time=None, include_ids=
         params["include_mission_name"] = True
     if include_updated_at:
         params["include_updated_at"] = True
-    
+
     params = {k: v for k, v in params.items() if v is not None}
     
     response = make_api_request(url, params=params)
@@ -111,13 +111,13 @@ def get_super_observations_page(since=None, min_time=None, max_time=None, includ
         params["max_time"] = to_unix_timestamp(max_time)
     if mission_id:
         params["mission_id"] = mission_id
-    if min_latitude:
+    if min_latitude is not None:
         params["min_latitude"] = min_latitude
-    if max_latitude:
+    if max_latitude is not None:
         params["max_latitude"] = max_latitude
-    if min_longitude:
+    if min_longitude is not None:
         params["min_longitude"] = min_longitude
-    if max_longitude:
+    if max_longitude is not None:
         params["max_longitude"] = max_longitude
     if include_ids:
         params["include_ids"] = True


### PR DESCRIPTION
## Summary

Implements 3 public API endpoints that are documented in oracle but were missing from the CLI/Python SDK, plus fixes a parameter gap in super_observations.

**New endpoints:**
- `get_available_stations()` / `windborne available_stations` — list ASOS weather stations
- `get_station_forecast(station_id)` / `windborne station_forecast <id>` — station-specific forecast
- `get_interpolated_sounding(coordinates, time)` / `windborne interpolated_sounding` — vertical atmospheric profile

**Bug fix:**
- `super_observations` and `super_observations_page` now support geographic filtering (`--min-latitude`, `--max-latitude`, `--min-longitude`, `--max-longitude`), matching the existing `observations` implementation

**Files changed (4, +228 lines):**
- `forecasts_api.py` — 3 new functions following existing conventions
- `observations_api.py` — geo params added to `get_super_observations_page()` and `get_super_observations()`
- `cli.py` — 3 new subcommands + geo flags on super_obs parsers/handlers
- `__init__.py` — exports for new functions

## Context

Full audit of oracle API docs vs CLI identified these as high-priority gaps — the docs reference CLI commands and Python imports that don't exist. See [#api > CLI bot](https://chat.windbornesystems.com/#narrow/channel/api/topic/CLI.20bot) for the full audit.

## Test plan

- [x] `windborne available_stations` returns station list
- [x] `windborne station_forecast panc output.json` returns forecast data
- [x] `windborne interpolated_sounding "40.7,-74.0" -t 2026-02-20T12:00:00Z output.json` returns sounding
- [x] `windborne super_observations --min-latitude 30 --max-latitude 50` filters correctly