### PR TITLE
Add analysis endpoints and wm-4.5-ens model to CLI

### DIFF
--- a/windborne/__init__.py
+++ b/windborne/__init__.py
@@ -44,7 +44,12 @@ from .forecasts_api import (
 
     get_population_weighted_hdds,
     get_population_weighted_cdds,
-    get_calculation_times_degree_days
+    get_calculation_times_degree_days,
+
+    get_analysis_available_times,
+    get_analysis_variables,
+    get_interpolated_analysis,
+    get_gridded_analysis
 )
 
 # Define what should be available when users import *
@@ -86,6 +91,11 @@ __all__ = [
     "get_population_weighted_hdds",
     "get_population_weighted_cdds",
     "get_calculation_times_degree_days",
+
+    "get_analysis_available_times",
+    "get_analysis_variables",
+    "get_interpolated_analysis",
+    "get_gridded_analysis",
 
     # API helpers
     "API_BASE_URL",

--- a/windborne/cli.py
+++ b/windborne/cli.py
@@ -744,7 +744,7 @@ def main():
             variable=args.variable,
             time=args.time,
             output_file=args.output_file,
-            format=args.format
+            output_format=args.format
         )
 
     else:

--- a/windborne/cli.py
+++ b/windborne/cli.py
@@ -35,7 +35,12 @@ from . import (
 
     get_available_stations,
     get_station_forecast,
-    get_interpolated_sounding
+    get_interpolated_sounding,
+
+    get_analysis_available_times,
+    get_analysis_variables,
+    get_interpolated_analysis,
+    get_gridded_analysis
 )
 
 from pprint import pprint
@@ -193,7 +198,7 @@ def main():
     points_parser.add_argument('-mh','--min-hour', type=int, help='Minimum forecast hour')
     points_parser.add_argument('-xh','--max-hour', type=int, help='Maximum forecast hour')
     points_parser.add_argument('-i', '--init-time', help='Initialization time')
-    points_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
+    points_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens)')
     points_parser.add_argument('output_file', nargs='?', help='Output file')
 
     # Interpolated Points Forecast Command
@@ -205,7 +210,7 @@ def main():
     points_interpolated_parser.add_argument('-xh','--max-hour', type=int, help='Maximum forecast hour')
     points_interpolated_parser.add_argument('-i', '--init-time', help='Initialization time')
     points_interpolated_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    points_interpolated_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
+    points_interpolated_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens)')
     points_interpolated_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
 
     # Station Forecasts
@@ -213,13 +218,13 @@ def main():
 
     # Available Stations Command
     available_stations_parser = subparsers.add_parser('available_stations', help='List all weather stations with station-specific forecasts')
-    available_stations_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
+    available_stations_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens)')
     available_stations_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
 
     # Station Forecast Command
     station_forecast_parser = subparsers.add_parser('station_forecast', help='Get weather forecast for a specific station')
     station_forecast_parser.add_argument('station_id', help='ICAO station identifier (e.g., PANC, KJFK, SFO)')
-    station_forecast_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
+    station_forecast_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens)')
     station_forecast_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
 
     # Interpolated Sounding Command
@@ -236,7 +241,7 @@ def main():
     gridded_parser = subparsers.add_parser('gridded', help='Get gridded forecast for a variable')
     gridded_parser.add_argument('args', nargs='*', help='variable time output_file')
     gridded_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    gridded_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    gridded_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
 
     # OTHER
     # TCS
@@ -245,7 +250,7 @@ def main():
     # Tropical Cyclones Command
     tropical_cyclones_parser = subparsers.add_parser('tropical_cyclones', help='Get tropical cyclone forecasts')
     tropical_cyclones_parser.add_argument('-b', '--basin',  help='Optional: filter tropical cyclones on basin[ NA, EP, WP, NI, SI, AU, SP]')
-    tropical_cyclones_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    tropical_cyclones_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
     tropical_cyclones_parser.add_argument('args', nargs='*',
                                  help='[optional: initialization time (YYYYMMDDHH, YYYY-MM-DDTHH, or YYYY-MM-DDTHH:mm:ss)] output_file')
 
@@ -253,14 +258,14 @@ def main():
     hdd_parser = subparsers.add_parser('hdds', help='Get forecasted population-weighted heating degree days (HDDs)')
     hdd_parser.add_argument('initialization_time', help='Initialization time (YYYYMMDDHH, YYYY-MM-DDTHH, or YYYY-MM-DDTHH:mm:ss)')
     hdd_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    hdd_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    hdd_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
     hdd_parser.add_argument('-o', '--output', help='Output file (supports .csv and .json formats)')
 
     # Population Weighted CDD Command
     cdd_parser = subparsers.add_parser('cdds', help='Get forecasted population-weighted cooling degree days (CDDs)')
     cdd_parser.add_argument('initialization_time', help='Initialization time (YYYYMMDDHH, YYYY-MM-DDTHH, or YYYY-MM-DDTHH:mm:ss)')
     cdd_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    cdd_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    cdd_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
     cdd_parser.add_argument('-o', '--output', help='Output file (supports .csv and .json formats)')
 
     # Calculation Times Command (with subcommand for degree_days)
@@ -268,28 +273,55 @@ def main():
     calculation_times_subparsers = calculation_times_parser.add_subparsers(dest='calculation_times_type', help='Calculation type')
     degree_days_parser = calculation_times_subparsers.add_parser('degree_days', help='Get available calculation times for degree days forecasts')
     degree_days_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    degree_days_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    degree_days_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
 
     # Initialization Times Command
     initialization_times_parser = subparsers.add_parser('init_times', help='Get available initialization times for point forecasts')
     initialization_times_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    initialization_times_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    initialization_times_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
 
     # Archived Initialization Times Command
     archived_initialization_times_parser = subparsers.add_parser('archived_init_times', help='Get available archived initialization times')
     archived_initialization_times_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    archived_initialization_times_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    archived_initialization_times_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
     archived_initialization_times_parser.add_argument('-p', '--page-end', help='End of page window (ISO 8601). Lists times back 7 days.')
 
     # Run Information Command
     run_information_parser = subparsers.add_parser('run_information', help='Get run information for a model run')
     run_information_parser.add_argument('initialization_time', help='Initialization time (ISO 8601)')
     run_information_parser.add_argument('-e', '--ens-member', help='Ensemble member (eg 1 or mean)')
-    run_information_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    run_information_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
 
     # Variables Command
     variables_parser = subparsers.add_parser('variables', help='Get available variables for a model')
-    variables_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm4-intra, ecmwf-det)')
+    variables_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4, wm-4.5-ens, ecmwf-det)')
+
+    ####################################################################################################################
+    # ANALYSIS API FUNCTIONS
+    ####################################################################################################################
+
+    # Analysis Available Times Command
+    analysis_times_parser = subparsers.add_parser('analysis_available_times', help='Get available analysis times for a source')
+    analysis_times_parser.add_argument('-s', '--source', default='ecmwf_det_anl', help='Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)')
+
+    # Analysis Variables Command
+    analysis_variables_parser = subparsers.add_parser('analysis_variables', help='Get available variables for an analysis source')
+    analysis_variables_parser.add_argument('-s', '--source', default='ecmwf_det_anl', help='Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)')
+
+    # Analysis Interpolated Command
+    analysis_interpolated_parser = subparsers.add_parser('analysis_interpolated', help='Get analysis data interpolated to specific coordinates')
+    analysis_interpolated_parser.add_argument('coordinates', help='Coordinate pairs in format "latitudeA,longitudeA; latitudeB,longitudeB"')
+    analysis_interpolated_parser.add_argument('time', help='Time to retrieve data for (ISO 8601)')
+    analysis_interpolated_parser.add_argument('-s', '--source', default='ecmwf_det_anl', help='Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)')
+    analysis_interpolated_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
+
+    # Analysis Gridded Command
+    analysis_gridded_parser = subparsers.add_parser('analysis_gridded', help='Get gridded analysis data for a variable')
+    analysis_gridded_parser.add_argument('variable', help='Variable to download (e.g., temperature_2m)')
+    analysis_gridded_parser.add_argument('time', help='Time to retrieve data for (ISO 8601)')
+    analysis_gridded_parser.add_argument('output_file', help='Output file path')
+    analysis_gridded_parser.add_argument('-s', '--source', default='ecmwf_det_anl', help='Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)')
+    analysis_gridded_parser.add_argument('-f', '--format', help='Output format (zarr or netcdf)')
 
     args = parser.parse_args()
 
@@ -685,6 +717,33 @@ def main():
             )
         else:
             calculation_times_parser.print_help()
+
+    ####################################################################################################################
+    # ANALYSIS API FUNCTIONS CALLED
+    ####################################################################################################################
+    elif args.command == 'analysis_available_times':
+        get_analysis_available_times(source=args.source, print_response=True)
+
+    elif args.command == 'analysis_variables':
+        get_analysis_variables(source=args.source, print_response=True)
+
+    elif args.command == 'analysis_interpolated':
+        get_interpolated_analysis(
+            source=args.source,
+            coordinates=args.coordinates,
+            time=args.time,
+            output_file=args.output_file,
+            print_response=(not args.output_file)
+        )
+
+    elif args.command == 'analysis_gridded':
+        get_gridded_analysis(
+            source=args.source,
+            variable=args.variable,
+            time=args.time,
+            output_file=args.output_file,
+            format=args.format
+        )
 
     else:
         parser.print_help()

--- a/windborne/forecasts_api.py
+++ b/windborne/forecasts_api.py
@@ -686,6 +686,10 @@ def get_interpolated_analysis(source='ecmwf_det_anl', coordinates=None, time=Non
                     coordinate_items.append(f"{coordinate['latitude']},{coordinate['longitude']}")
                 elif 'lat' in coordinate and 'lon' in coordinate:
                     coordinate_items.append(f"{coordinate['lat']},{coordinate['lon']}")
+                elif 'lat' in coordinate and 'long' in coordinate:
+                    coordinate_items.append(f"{coordinate['lat']},{coordinate['long']}")
+                elif 'lat' in coordinate and 'lng' in coordinate:
+                    coordinate_items.append(f"{coordinate['lat']},{coordinate['lng']}")
                 else:
                     print("Coordinates should be dictionaries with keys 'latitude' and 'longitude'.")
                     return
@@ -726,7 +730,7 @@ def get_interpolated_analysis(source='ecmwf_det_anl', coordinates=None, time=Non
     return response
 
 
-def get_gridded_analysis(source='ecmwf_det_anl', variable=None, time=None, output_file=None, format=None):
+def get_gridded_analysis(source='ecmwf_det_anl', variable=None, time=None, output_file=None, output_format=None):
     """
     Get gridded analysis data for a variable.
 
@@ -735,7 +739,7 @@ def get_gridded_analysis(source='ecmwf_det_anl', variable=None, time=None, outpu
         variable (str): Variable to download (e.g., temperature_2m)
         time (str): Time to retrieve data for (ISO 8601)
         output_file (str): Path to save output file (.nc or .zarr)
-        format (str, optional): Output format (zarr or netcdf)
+        output_format (str, optional): Output format (zarr or netcdf)
 
     Returns:
         Response object or None
@@ -751,8 +755,8 @@ def get_gridded_analysis(source='ecmwf_det_anl', variable=None, time=None, outpu
         "variable": variable,
         "time": parse_time(time),
     }
-    if format:
-        params["format"] = format
+    if output_format:
+        params["format"] = output_format
 
     response = make_api_request(f"{FORECASTS_API_BASE_URL}/{source}/analysis/gridded", params=params, as_json=False)
 
@@ -760,7 +764,12 @@ def get_gridded_analysis(source='ecmwf_det_anl', variable=None, time=None, outpu
         return None
 
     if output_file:
-        download_and_save_output(output_file, response)
+        if output_format == 'zarr' or output_file.endswith('.zarr'):
+            with open(output_file, 'wb') as f:
+                f.write(response.content)
+            print(f"Data Successfully saved to {output_file}")
+        else:
+            download_and_save_output(output_file, response)
 
     return response
 

--- a/windborne/forecasts_api.py
+++ b/windborne/forecasts_api.py
@@ -593,6 +593,178 @@ def get_population_weighted_cdds(initialization_time, ens_member=None, output_fi
     return response
 
 
+def get_analysis_available_times(source='ecmwf_det_anl', print_response=False):
+    """
+    Get available analysis times for a given source.
+
+    Args:
+        source (str): Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)
+        print_response (bool, optional): Whether to print formatted output
+
+    Returns:
+        dict: API response with available times, latest, and source
+    """
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{source}/analysis/available_times")
+
+    if print_response and response is not None:
+        print("Source:", response.get('source'))
+        print("Latest:", response.get('latest'))
+        print("Available times:")
+        for t in response.get('available', []):
+            print(f" - {t}")
+
+    return response
+
+
+def get_analysis_variables(source='ecmwf_det_anl', print_response=False):
+    """
+    Get available variables for a given analysis source.
+
+    Args:
+        source (str): Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)
+        print_response (bool, optional): Whether to print formatted output
+
+    Returns:
+        dict: API response with analysis variables, levels
+    """
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{source}/variables")
+
+    if print_response and response is not None:
+        analysis = response.get('analysis', response)
+        sfc = analysis.get('sfc_variables', [])
+        upper = analysis.get('upper_variables', [])
+        levels = analysis.get('levels', [])
+
+        print("Surface variables:")
+        for v in sfc:
+            print(f" - {v}")
+
+        if upper:
+            print("Upper variables:")
+            for v in upper:
+                print(f" - {v}")
+
+        if levels:
+            print("Levels:")
+            for lvl in levels:
+                print(f" - {lvl}")
+
+    return response
+
+
+def get_interpolated_analysis(source='ecmwf_det_anl', coordinates=None, time=None, output_file=None, print_response=False):
+    """
+    Get analysis data interpolated to specific coordinates.
+
+    Args:
+        source (str): Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)
+        coordinates (str|list): Coordinates as "lat,lon;lat,lon" or list of tuples/dicts
+        time (str): Time to retrieve data for (ISO 8601)
+        output_file (str, optional): Path to save response (.json or .csv)
+        print_response (bool, optional): Whether to print formatted output
+
+    Returns:
+        dict: API response with analysis data
+    """
+    if not coordinates:
+        print("To get interpolated analysis you must provide coordinates.")
+        return
+
+    formatted_coordinates = coordinates
+    if isinstance(coordinates, list):
+        coordinate_items = []
+        for coordinate in coordinates:
+            if isinstance(coordinate, (tuple, list)):
+                if len(coordinate) != 2:
+                    print("Coordinates should be tuples or lists with two elements: latitude and longitude.")
+                    return
+                coordinate_items.append(f"{coordinate[0]},{coordinate[1]}")
+            elif isinstance(coordinate, str):
+                coordinate_items.append(coordinate)
+            elif isinstance(coordinate, dict):
+                if 'latitude' in coordinate and 'longitude' in coordinate:
+                    coordinate_items.append(f"{coordinate['latitude']},{coordinate['longitude']}")
+                elif 'lat' in coordinate and 'lon' in coordinate:
+                    coordinate_items.append(f"{coordinate['lat']},{coordinate['lon']}")
+                else:
+                    print("Coordinates should be dictionaries with keys 'latitude' and 'longitude'.")
+                    return
+        formatted_coordinates = ";".join(coordinate_items)
+
+    formatted_coordinates = formatted_coordinates.replace(" ", "")
+
+    if not time:
+        print("To get interpolated analysis you must provide a time.")
+        return
+
+    params = {
+        "coordinates": formatted_coordinates,
+        "time": parse_time(time),
+    }
+
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{source}/analysis/interpolated", params=params)
+
+    if output_file:
+        save_arbitrary_response(output_file, response, csv_data_key='analysis')
+
+    if print_response and response is not None:
+        print(f"Source: {response.get('source')}")
+        print(f"Time: {response.get('time')}")
+
+        analysis = response.get('analysis', [])
+        keys = ['time', 'temperature_2m', 'dewpoint_2m', 'wind_u_10m', 'wind_v_10m', 'precipitation', 'pressure_msl', 'latitude', 'longitude']
+        headers = ['Time', '2m Temp (°C)', '2m Dewpoint (°C)', 'Wind U (m/s)', 'Wind V (m/s)', 'Precip (mm)', 'MSL Pressure (hPa)', 'Latitude', 'Longitude']
+
+        for i, point_data in enumerate(analysis):
+            if isinstance(point_data, list):
+                print(f"\nPoint {i+1}:")
+                print_table(point_data, keys=keys, headers=headers)
+            elif isinstance(point_data, dict):
+                print(f"\nPoint {i+1}:")
+                print_table([point_data], keys=keys, headers=headers)
+
+    return response
+
+
+def get_gridded_analysis(source='ecmwf_det_anl', variable=None, time=None, output_file=None, format=None):
+    """
+    Get gridded analysis data for a variable.
+
+    Args:
+        source (str): Analysis source (ecmwf_det_anl, ecmwf_ens_anl, era5)
+        variable (str): Variable to download (e.g., temperature_2m)
+        time (str): Time to retrieve data for (ISO 8601)
+        output_file (str): Path to save output file (.nc or .zarr)
+        format (str, optional): Output format (zarr or netcdf)
+
+    Returns:
+        Response object or None
+    """
+    if not variable:
+        print("To get gridded analysis you must provide a variable.")
+        return
+    if not time:
+        print("To get gridded analysis you must provide a time.")
+        return
+
+    params = {
+        "variable": variable,
+        "time": parse_time(time),
+    }
+    if format:
+        params["format"] = format
+
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{source}/analysis/gridded", params=params, as_json=False)
+
+    if response is None:
+        return None
+
+    if output_file:
+        download_and_save_output(output_file, response)
+
+    return response
+
+
 def get_calculation_times_degree_days(ens_member=None, print_response=False, model='wm'):
     """
     Get available calculation times for degree days forecasts.

--- a/windborne/forecasts_api.py
+++ b/windborne/forecasts_api.py
@@ -709,13 +709,13 @@ def get_interpolated_analysis(source='ecmwf_det_anl', coordinates=None, time=Non
     response = make_api_request(f"{FORECASTS_API_BASE_URL}/{source}/analysis/interpolated", params=params)
 
     if output_file:
-        save_arbitrary_response(output_file, response, csv_data_key='analysis')
+        save_arbitrary_response(output_file, response, csv_data_key='forecasts')
 
     if print_response and response is not None:
         print(f"Source: {response.get('source')}")
         print(f"Time: {response.get('time')}")
 
-        analysis = response.get('analysis', [])
+        analysis = response.get('forecasts', [])
         keys = ['time', 'temperature_2m', 'dewpoint_2m', 'wind_u_10m', 'wind_v_10m', 'precipitation', 'pressure_msl', 'latitude', 'longitude']
         headers = ['Time', '2m Temp (°C)', '2m Dewpoint (°C)', 'Wind U (m/s)', 'Wind V (m/s)', 'Precip (mm)', 'MSL Pressure (hPa)', 'Latitude', 'Longitude']
 


### PR DESCRIPTION
## Summary
- Add 4 analysis CLI commands: `analysis_available_times`, `analysis_variables`, `analysis_interpolated`, `analysis_gridded` with `--source` param (ecmwf_det_anl, ecmwf_ens_anl, era5)
- Add corresponding Python SDK functions: `get_analysis_available_times`, `get_analysis_variables`, `get_interpolated_analysis`, `get_gridded_analysis`
- Update model help text across all forecast commands to include `wm-4.5-ens`

Closes the two outstanding CLI sync gaps flagged in the daily API-CLI sync audits since Mar 13.

Requester: sai@windbornesystems.com

## Test plan
- [ ] Verify `windborne analysis_available_times -s ecmwf_det_anl` returns available times
- [ ] Verify `windborne analysis_variables -s era5` returns variable list
- [ ] Verify `windborne analysis_interpolated "37.77,-122.42" 2026-02-01T00:00:00Z -s ecmwf_det_anl` returns interpolated data
- [ ] Verify `windborne analysis_gridded temperature_2m 2026-02-01T00:00:00Z output.nc -s ecmwf_det_anl` downloads gridded data
- [ ] Verify `windborne points_interpolated "37,-122" -m wm-4.5-ens -e mean` works with new model
- [ ] Verify `windborne --help` shows all new commands