### PR TITLE
Add initialization_time to get_station_forecast

### DIFF
--- a/windborne/cli.py
+++ b/windborne/cli.py
@@ -219,6 +219,7 @@ def main():
     # Station Forecast Command
     station_forecast_parser = subparsers.add_parser('station_forecast', help='Get weather forecast for a specific station')
     station_forecast_parser.add_argument('station_id', help='ICAO station identifier (e.g., PANC, KJFK, SFO)')
+    station_forecast_parser.add_argument('-i', '--init-time', help='Initialization time (ISO 8601)')
     station_forecast_parser.add_argument('-m', '--model', default='wm', help='Forecast model (e.g., wm, wm4)')
     station_forecast_parser.add_argument('output_file', nargs='?', help='Output file (.csv or .json)')
 
@@ -558,6 +559,7 @@ def main():
     elif args.command == 'station_forecast':
         get_station_forecast(
             station_id=args.station_id,
+            initialization_time=args.init_time,
             output_file=args.output_file,
             model=args.model,
             print_response=(not args.output_file)

--- a/windborne/forecasts_api.py
+++ b/windborne/forecasts_api.py
@@ -650,12 +650,14 @@ def get_available_stations(output_file=None, print_response=False, model='wm'):
     return response
 
 
-def get_station_forecast(station_id, output_file=None, print_response=False, model='wm'):
+def get_station_forecast(station_id, initialization_time=None, output_file=None, print_response=False, model='wm'):
     """
     Get the weather forecast for a specific ASOS station.
 
     Args:
         station_id (str): ICAO station identifier (e.g., PANC, KJFK, SFO)
+        initialization_time (str, optional): Initialization time in ISO 8601 format (YYYY-MM-DDTHH:00:00).
+                                              If omitted, latest is used.
         output_file (str, optional): Path to save the response data (.json or .csv)
         print_response (bool, optional): Whether to print a formatted table
         model (str, optional): Forecast model (e.g., wm, wm4)
@@ -668,7 +670,11 @@ def get_station_forecast(station_id, output_file=None, print_response=False, mod
         print("To get a station forecast you must provide a station_id.")
         return
 
-    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{model}/point_forecast/stations/{station_id}")
+    params = {}
+    if initialization_time:
+        params['initialization_time'] = parse_time(initialization_time, init_time_flag=True)
+
+    response = make_api_request(f"{FORECASTS_API_BASE_URL}/{model}/point_forecast/stations/{station_id}", params=params)
 
     if output_file:
         save_arbitrary_response(output_file, response, csv_data_key='forecast')


### PR DESCRIPTION
## Summary
- Adds `initialization_time` parameter to `get_station_forecast()` in the Python SDK
- Adds `-i`/`--init-time` CLI flag to the `station_forecast` command
- When omitted, behavior is unchanged (returns latest forecast)

Fixes the issue reported in [#api-issues > get_station_forecast initialization time](https://chat.windbornesystems.com/#narrow/channel/api-issues/topic/get_station_forecast.20initialization.20time) — the backend already supports querying by init time, but the SDK didn't expose it.

Requester: lucas@windbornesystems.com ([trigger message](https://chat.windbornesystems.com/#narrow/channel/452-llms-lucas/topic/channel.20events/with/20941102))

## Usage

```python
from windborne import get_station_forecast

# Latest (unchanged behavior)
forecast = get_station_forecast(station_id="panc", model="wm-5c")

# Specific initialization time
forecast = get_station_forecast(station_id="panc", model="wm-5c", initialization_time="2026-03-18T09:20:00Z")
```

```bash
# CLI
windborne station_forecast panc -m wm-5c -i 2026-03-18T09:20:00Z
```

## Test plan
- [ ] Verify `get_station_forecast("panc", model="wm-5c")` still returns latest
- [ ] Verify `get_station_forecast("panc", model="wm-5c", initialization_time="2026-03-18T09:20:00Z")` returns forecast for that specific init time
- [ ] Verify CLI: `windborne station_forecast panc -m wm-5c -i 2026-03-18T09:20:00Z`