### PR TITLE
Support ISO 8601 timestamps without milliseconds

### DIFF
--- a/windborne/utils.py
+++ b/windborne/utils.py
@@ -27,6 +27,7 @@ def to_unix_timestamp(date_string):
             "%Y-%m-%d %H:%M:%S",        # e.g., 2024-12-05 14:48:00
             "%Y-%m-%d_%H:%M",           # e.g., 2024-12-05_14:48
             "%Y-%m-%dT%H:%M:%S.%fZ",    # e.g., 2024-12-05T14:48:00.000Z
+            "%Y-%m-%dT%H:%M:%SZ",       # e.g., 2024-12-05T14:48:00Z
             "%Y%m%d%H",                 # e.g., 2024120514
         ]
         for fmt in formats:
@@ -41,6 +42,7 @@ def to_unix_timestamp(date_string):
               "- YYYY-MM-DD HH:MM:SS\n"
               "- YYYY-MM-DD_HH:MM\n"
               "- YYYY-MM-DDTHH:MM:SS.fffZ\n"
+              "- YYYY-MM-DDTHH:MM:SSZ\n"
               "- YYYYMMDDHH")
         exit(1)
 


### PR DESCRIPTION
## Summary
- `to_unix_timestamp()` in `utils.py` rejected standard ISO 8601 timestamps like `2026-05-01T00:00:00Z` because the only ISO format it accepted required milliseconds (`2026-05-01T00:00:00.000Z`)
- Adds `%Y-%m-%dT%H:%M:%SZ` to the format list so both forms work
- Updates the error message to list the new format

## Context
Reported by Todd Hutchinson in [#weather > create netcdf shodan](https://chat.windbornesystems.com/#narrow/channel/33-weather/topic/create.20netcdf.20shodan/with/25605415) while testing `get_super_observations(..., output_format='netcdf')`.

Requester: todd@windbornesystems.com

## Test plan
- [x] Verified `2026-05-01T00:00:00Z` now parses to correct Unix timestamp (1777593600)
- [x] Verified `2026-05-01T00:00:00.000Z` still works and produces identical timestamp
- [ ] Run existing tests if any